### PR TITLE
Exclude ecs-init (and docker) from upgrading

### DIFF
--- a/aws/ecs/packer/template.json
+++ b/aws/ecs/packer/template.json
@@ -39,6 +39,10 @@
   }, {
     "type": "shell",
     "inline": [
+      "# Exclude ecs-init (and docker) from upgrades until https://github.com/aws/amazon-ecs-init/pull/27 is merged and released",
+      "sudo yum -y update # make sure all packages are up to date to minimize the impact of the exlusion",
+      "sudo bash -c 'echo exclude=ecs-init docker >> /etc/yum.conf'",
+	  
       "sudo yum -y install python-pip jq",
       "sudo python-pip install awscli",
 
@@ -58,7 +62,7 @@
       "sudo chmod +x /etc/weave/peers.sh",
 
       "# Remove all ECS execution traces added while running packer",
-      "sudo stop ecs",
+      "sudo stop ecs || true",
       "sudo docker rm ecs-agent 2> /dev/null || true",
       "sudo rm -rf /var/log/ecs/* /var/lib/ecs/data/*"
     ]


### PR DESCRIPTION
Until https://github.com/aws/amazon-ecs-init/pull/27 is merged and released

Mitigates #4