### PR TITLE
Really bundle Weave 1.2

### DIFF
--- a/aws/ecs/CHANGELOG.md
+++ b/aws/ecs/CHANGELOG.md
@@ -1,9 +1,15 @@
+## Weaveworks ECS Image (2015-10-26)
+
+Bug fixes:
+- Really bundle Weave 1.2
+  [#33](https://github.com/weaveworks/integrations/issues/33)
+
 ## Weaveworks ECS Image (2015-10-22)
 
 New features:
 - Update base images to the latest version (2015.09.a)
   [#30](https://github.com/weaveworks/integrations/pull/10)
-- Use Weave 1.1.2
+- Use Weave 1.2 (**EDIT**: not really, the 2015-10-26 release fixes this)
   [#31](https://github.com/weaveworks/integrations/pull/18)
 
 Bug fixes:

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -14,12 +14,12 @@ not remove it and respect the format! -->
 
 | Region         | AMI          |
 |----------------|--------------|
-| us-east-1      | ami-8fb9e5ea |
-| us-west-1      | ami-8fef2ccb |
-| us-west-2      | ami-b2907281 |
-| eu-west-1      | ami-55f0cf22 |
-| ap-northeast-1 | ami-f65835f6 |
-| ap-southeast-2 | ami-a3cc8699 |
+| us-east-1      | ami-c9673fac |
+| us-west-1      | ami-a577b4e1 |
+| us-west-2      | ami-24db3617 |
+| eu-west-1      | ami-bb2b12cc |
+| ap-northeast-1 | ami-548fe054 |
+| ap-southeast-2 | ami-f75500cd |
 
 
 ## Build Your Own Weave ECS AMI


### PR DESCRIPTION
Packer was run in the wrong branch in the previous release

Fixes #33 