### PR TITLE
Use weave:peerGroupName tag to identify peers

### DIFF
--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -62,10 +62,11 @@ Besides the Amazon ECS API actions required by all container instances,
 (particularily those indicated in the
 [`AmazonEC2ContainerServiceforEC2Role`](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html)
 managed policy), to ensure that instance peers can be discovered, any instances
-using the Weave ECS AMI also require the following two actions:
+using the Weave ECS AMI also require the following three actions:
 
 1. `ec2:DescribeInstances`
-2. `autoscaling:DescribeAutoScalingInstances`
+2. `ec2:DescribeTags`
+3. `autoscaling:DescribeAutoScalingInstances`
 
 [`weave-ecs-policy.json`](https://github.com/weaveworks/guides/blob/master/aws-ecs/data/weave-ecs-policy.json#L16-L17)
 (see the guide
@@ -75,20 +76,24 @@ which describes the minimal policy definition.)
 For more information on IAM policies see
 [IAM Policies for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-for-amazon-ec2.html).
 
-### 3. Auto Scaling Group Membership
+### 3. Peer discovery requirements
 
-Amazon ECS container instances must be a member of an
+To form a Weave network, the Amazon ECS container instances must either/or:
+* be a member of an
 [Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroup.html)
-to join a Weave network.
+* be [tagged](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) as `weave:peerGroupName=foo`, where `foo` is a groupname of your choince
 
 ## Peer Discovery
 
-At boot time, instances running the ECS Weave AMI form a Weave network with all
-the other instances in the same
-[Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroup.html).
+At boot time, an instance running the ECS Weave AMI will try to join other instances to form a Weave network.
 
-The `Weave Scope` probes also report back to the apps running in all the instances from the same auto scaling group when
-running in standalone mode.
+* If the instance is
+  [tagged](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html)
+  with `weave:peerGroupName=foo`, it will join other instances also
+  tagged as `weave:peerGroupName=foo`.
+* Otherwise it will join all the other instances in the same [Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroup.html).
+
+When running `Weave Scope` in Standalone mode, probes discover apps using the same mechanism.
 
 ## Weave Scope
 

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -89,9 +89,12 @@ At boot time, an instance running the ECS Weave AMI will try to join other insta
 
 * If the instance is
   [tagged](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html)
-  with `weave:peerGroupName=foo`, it will join other instances also
-  tagged as `weave:peerGroupName=foo`.
-* Otherwise it will join all the other instances in the same [Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroup.html).
+  with `weave:peerGroupName=foo`, it will join other instances also tagged as
+  `weave:peerGroupName=foo`. Note that for this to work, the instances need to
+  be tagged immediately after creation so that the tag is available by the time
+  Weave is launched.
+* Otherwise it will join all the other instances in the same
+  [Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroup.html).
 
 When running `Weave Scope` in Standalone mode, probes discover apps using the same mechanism.
 

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -499,6 +499,7 @@
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
                     "ec2:DescribeInstances",
+                    "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"
                   ],
                   "Resource": [

--- a/aws/ecs/cloudformation.json
+++ b/aws/ecs/cloudformation.json
@@ -462,6 +462,7 @@
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
                     "ec2:DescribeInstances",
+                    "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"
                   ],
                   "Resource": [

--- a/aws/ecs/packer/to-upload/peers.sh
+++ b/aws/ecs/packer/to-upload/peers.sh
@@ -7,24 +7,20 @@ aws=/usr/local/bin/aws
 export AWS_DEFAULT_REGION=$(curl -s curl http://169.254.169.254/latest/dynamic/instance-identity/document | \
                             jq -r .region)
 current_instance_id=$(curl -s curl http://169.254.169.254/latest/meta-data/instance-id)
-current_autoscaling_group=$($aws autoscaling describe-auto-scaling-instances | \
-                            jq -r ".AutoScalingInstances[] | select(.InstanceId == \"$current_instance_id\") | .AutoScalingGroupName")
+current_autoscaling_group=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?InstanceId==\`$current_instance_id\`].AutoScalingGroupName"  --output text)
 
 if [ -z "$current_autoscaling_group" ]; then
   >&2 echo "instance doesn't belong to an autoscaling group"
   exit 1
 fi
 
-peer_instances=$($aws autoscaling describe-auto-scaling-instances | \
-                jq -r ".AutoScalingInstances[] | select(.AutoScalingGroupName == \"$current_autoscaling_group\" and .InstanceId != \"$current_instance_id\") | .InstanceId")
+peer_instances=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[? AutoScalingGroupName==\`$current_autoscaling_group\` && InstanceId!=\`$current_instance_id\`].InstanceId" --output text)
 
 if [ -z "$peer_instances" ]; then
 # no peers found
   exit 0
 fi
 
-peer_ips=$($aws ec2 describe-instances --instance-ids $peer_instances | \
-	jq -r '.Reservations | .[] | .Instances | .[] | .NetworkInterfaces | .[] | .PrivateIpAddress')
+peer_ips=$($aws ec2 describe-instances --instance-ids $peer_instances --query 'Reservations[].Instances[].NetworkInterfaces[].PrivateIpAddress' --output text)
+echo $peer_ips
 
-echo $peer_ips | tr '\n' ' '
-echo

--- a/aws/ecs/packer/to-upload/peers.sh
+++ b/aws/ecs/packer/to-upload/peers.sh
@@ -1,20 +1,32 @@
 #!/bin/bash
-# This script print a list of IPs of the EC2 instances in your current Autoscaling Group.
 set -eu
+# This script prints the list of Weave peers (IPs) of the EC2 instance executing the script.
+# The peers are idenfied as follows:
+# If the current instance is tagged with weave:peerGroupName=VALUE -> all other instances tagged as weave:peerGroupName=VALUE
+# Otherwise, all the other instances in the same Autoscaling Group (default)
 
 aws=/usr/local/bin/aws
 
-export AWS_DEFAULT_REGION=$(curl -s curl http://169.254.169.254/latest/dynamic/instance-identity/document | \
-                            jq -r .region)
-current_instance_id=$(curl -s curl http://169.254.169.254/latest/meta-data/instance-id)
-current_autoscaling_group=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?InstanceId==\`$current_instance_id\`].AutoScalingGroupName"  --output text)
 
-if [ -z "$current_autoscaling_group" ]; then
-  >&2 echo "instance doesn't belong to an autoscaling group"
-  exit 1
+export AWS_DEFAULT_REGION=$(curl -s curl http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+current_instance_id=$(curl -s curl http://169.254.169.254/latest/meta-data/instance-id)
+
+PEER_GROUP_NAME=$($aws ec2 describe-instances --instance-ids $current_instance_id --query 'Reservations[0].Instances[0].Tags[?Key==`weave:peerGroupName`].Value' --output text)
+
+if [ -n "$PEER_GROUP_NAME" ]; then
+    peer_instances=$($aws ec2 describe-tags --filters "Name=resource-type,Values=instance,Name=tag:weave:peerGroupName,Values=$PEER_GROUP_NAME" --query "Tags[?ResourceId!=\`$current_instance_id\`].ResourceId" --output text)
+
+else
+    current_autoscaling_group=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?InstanceId==\`$current_instance_id\`].AutoScalingGroupName"  --output text)
+
+    if [ -z "$current_autoscaling_group" ]; then
+	>&2 echo "instance doesn't belong to an autoscaling group"
+	exit 1
+    fi
+
+    peer_instances=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[? AutoScalingGroupName==\`$current_autoscaling_group\` && InstanceId!=\`$current_instance_id\`].InstanceId" --output text)
 fi
 
-peer_instances=$($aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[? AutoScalingGroupName==\`$current_autoscaling_group\` && InstanceId!=\`$current_instance_id\`].InstanceId" --output text)
 
 if [ -z "$peer_instances" ]; then
 # no peers found


### PR DESCRIPTION
Fixes #1

Improves #73

@bryanvaz PTAL. I have never used spot fleets, but the documentation shows they queried in the same way as normal instances, so I think this should work. I would appreciate if you could verify it though.