### PR TITLE
Release

### DIFF
--- a/aws/ecs/CHANGELOG.md
+++ b/aws/ecs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Weaveworks ECS Image (2016-11-29)
+New features [#117](github.com/weaveworks/integrations/pull/117):
+- Update Weave Net to 1.8.1
+- Update Weave Scope to 1.1.0
+- Enable Scope ECS views
+- Add documentation for new actions required for Scope ECS views
+- Update base ECS images (including new Ohio region)
+
 ## Weaveworks ECS Image (2016-09-22)
 
 New features:

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -18,24 +18,25 @@ not remove it and respect the format! -->
 
 | Region         | AMI          |
 |----------------|--------------|
-| us-east-1      | ami-3fc1b928 |
-| us-west-1      | ami-4c2a642c |
-| us-west-2      | ami-de08d4be |
-| eu-west-1      | ami-dba2d8a8 |
-| eu-central-1   | ami-81738eee |
-| ap-northeast-1 | ami-4cbb692d |
-| ap-southeast-1 | ami-bb6cc9d8 |
-| ap-southeast-2 | ami-0de1d16e |
+| us-east-1      | ?? |
+| us-east-2      | ?? |
+| us-west-1      | ?? |
+| us-west-2      | ?? |
+| eu-west-1      | ?? |
+| eu-central-1   | ?? |
+| ap-northeast-1 | ?? |
+| ap-southeast-1 | ?? |
+| ap-southeast-2 | ?? |
 
 
 ## What's in the Weave ECS AMIs?
 
 These latest Weave ECS AMIs are based on Amazon's
 [ECS-Optimized Amazon Linux AMI](https://aws.amazon.com/marketplace/pp/B00U6QTYI2),
-version `2016.03.i` and also includes:
+version `2016.09.b` and also includes:
 
-* [Weave Net 1.7.2](https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-172)
-* [Weave Scope 0.17.1](https://github.com/weaveworks/scope/blob/master/CHANGELOG.md#release-0171)
+* [Weave Net 1.8.1](https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-181)
+* [Weave Scope 1.1.0](https://github.com/weaveworks/scope/blob/master/CHANGELOG.md#release-110)
 
 
 ## Deployment Requirements
@@ -64,9 +65,16 @@ Besides the customary Amazon ECS API actions required by all container instances
 1. `ec2:DescribeInstances`
 2. `ec2:DescribeTags`
 3. `autoscaling:DescribeAutoScalingInstances`
+4. `ecs:ListServices`
+5. `ecs:DescribeTasks`
+6. `ecs:DescribeServices`
 
-These extra actions are needed for discovering instance peers. [`weave-ecs-policy.json`](https://github.com/weaveworks/guides/blob/41f1f5a60d39d39b78f0e06e224a7c3bad30c4e8/aws-ecs/data/weave-ecs-policy.json#L16-L18) (from the
-[Weaveworks ECS guide](http://weave.works/guides/service-discovery-with-weave-aws-ecs.html)), describes the minimal policy definition.
+These extra actions are needed for discovering instance peers (1,2,3) and
+creating the ECS views in Weave Scope
+(4,5,6). [`weave-ecs-policy.json`](https://github.com/weaveworks/guides/blob/41f1f5a60d39d39b78f0e06e224a7c3bad30c4e8/aws-ecs/data/weave-ecs-policy.json#L16-L18)
+(from the
+[Weaveworks ECS guide](http://weave.works/guides/service-discovery-with-weave-aws-ecs.html)),
+describes the minimal policy definition.
 
 For more information on IAM policies see
 [IAM Policies for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-for-amazon-ec2.html).

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -18,15 +18,15 @@ not remove it and respect the format! -->
 
 | Region         | AMI          |
 |----------------|--------------|
-| us-east-1      | ?? |
-| us-east-2      | ?? |
-| us-west-1      | ?? |
-| us-west-2      | ?? |
-| eu-west-1      | ?? |
-| eu-central-1   | ?? |
-| ap-northeast-1 | ?? |
-| ap-southeast-1 | ?? |
-| ap-southeast-2 | ?? |
+| us-east-1      | ami-c63709d1 |
+| us-east-2      | ami-4788d222 |
+| us-west-1      | ami-28e7b348 |
+| us-west-2      | ami-c62f81a6 |
+| eu-west-1      | ami-25adf356 |
+| eu-central-1   | ami-7fd31410 |
+| ap-northeast-1 | ami-cb1eafaa |
+| ap-southeast-1 | ami-35822f56 |
+| ap-southeast-2 | ami-06300965 |
 
 
 ## What's in the Weave ECS AMIs?

--- a/aws/ecs/cloudformation-identiorca.json
+++ b/aws/ecs/cloudformation-identiorca.json
@@ -55,28 +55,31 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-3d55272a"
+        "ImageId": "ami-eca289fb"
       },
+      "us-east-2": {
+        "ImageId": "ami-446f3521"
+      },      
       "us-west-1": {
-        "ImageId": "ami-444d0224"
+        "ImageId": "ami-9fadf8ff"
       },
       "us-west-2": {
-        "ImageId": "ami-1ccd1f7c"
+        "ImageId": "ami-7abc111a"
       },
       "eu-west-1": {
-        "ImageId": "ami-b6760fc5"
+        "ImageId": "ami-a1491ad2"
       },
       "eu-central-1": {
-        "ImageId": "ami-f562909a"
+        "ImageId": "ami-54f5303b"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-096cba68"
+        "ImageId": "ami-9cd57ffd"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-7934ee1a"
+        "ImageId": "ami-a900a3ca"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-22a49541"
+        "ImageId": "ami-5781be34"
       }
     }
   },
@@ -496,6 +499,9 @@
                     "ecs:ListClusters",
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
+    		    "ecs:ListServices",
+                    "ecs:DescribeTasks",
+                    "ecs:DescribeServices",
                     "ec2:DescribeInstances",
                     "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"
@@ -652,7 +658,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.7.2",
+                      "v1.8.1",
                       "weave"
                     ]
                   ]
@@ -665,7 +671,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v0.17.1",
+                      "v1.1.0",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -503,7 +503,7 @@
                     "ecs:ListClusters",
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
-		    "ecs:ListServices",
+                    "ecs:ListServices",
                     "ecs:DescribeTasks",
                     "ecs:DescribeServices",
                     "ec2:DescribeInstances",

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -15,28 +15,31 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-3d55272a"
+        "ImageId": "ami-eca289fb"
       },
+      "us-east-2": {
+        "ImageId": "ami-446f3521"
+      },      
       "us-west-1": {
-        "ImageId": "ami-444d0224"
+        "ImageId": "ami-9fadf8ff"
       },
       "us-west-2": {
-        "ImageId": "ami-1ccd1f7c"
+        "ImageId": "ami-7abc111a"
       },
       "eu-west-1": {
-        "ImageId": "ami-b6760fc5"
+        "ImageId": "ami-a1491ad2"
       },
       "eu-central-1": {
-        "ImageId": "ami-f562909a"
+        "ImageId": "ami-54f5303b"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-096cba68"
+        "ImageId": "ami-9cd57ffd"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-7934ee1a"
+        "ImageId": "ami-a900a3ca"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-22a49541"
+        "ImageId": "ami-5781be34"
       }
     }
   },
@@ -110,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.7.2"
+      "Default": "v1.8.1"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v0.17.1"
+      "Default": "v1.1.0"
     }
   },
   "Conditions": {
@@ -500,6 +503,9 @@
                     "ecs:ListClusters",
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
+		    "ecs:ListServices",
+                    "ecs:DescribeTasks",
+                    "ecs:DescribeServices",
                     "ec2:DescribeInstances",
                     "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"

--- a/aws/ecs/cloudformation-no-app.json
+++ b/aws/ecs/cloudformation-no-app.json
@@ -36,28 +36,31 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-3d55272a"
+        "ImageId": "ami-eca289fb"
       },
+      "us-east-2": {
+        "ImageId": "ami-446f3521"
+      },      
       "us-west-1": {
-        "ImageId": "ami-444d0224"
+        "ImageId": "ami-9fadf8ff"
       },
       "us-west-2": {
-        "ImageId": "ami-1ccd1f7c"
+        "ImageId": "ami-7abc111a"
       },
       "eu-west-1": {
-        "ImageId": "ami-b6760fc5"
+        "ImageId": "ami-a1491ad2"
       },
       "eu-central-1": {
-        "ImageId": "ami-f562909a"
+        "ImageId": "ami-54f5303b"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-096cba68"
+        "ImageId": "ami-9cd57ffd"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-7934ee1a"
+        "ImageId": "ami-a900a3ca"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-22a49541"
+        "ImageId": "ami-5781be34"
       }
     }
   },
@@ -380,6 +383,9 @@
                     "ecs:ListClusters",
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
+		    "ecs:ListServices",
+                    "ecs:DescribeTasks",
+                    "ecs:DescribeServices",
                     "ec2:DescribeInstances",
                     "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"
@@ -536,7 +542,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.7.2",
+                      "v1.8.1",
                       "weave"
                     ]
                   ]
@@ -549,7 +555,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v0.17.1",
+                      "v1.1.0",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation.json
+++ b/aws/ecs/cloudformation.json
@@ -15,28 +15,31 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-3d55272a"
+        "ImageId": "ami-eca289fb"
       },
+      "us-east-2": {
+        "ImageId": "ami-446f3521"
+      },      
       "us-west-1": {
-        "ImageId": "ami-444d0224"
+        "ImageId": "ami-9fadf8ff"
       },
       "us-west-2": {
-        "ImageId": "ami-1ccd1f7c"
+        "ImageId": "ami-7abc111a"
       },
       "eu-west-1": {
-        "ImageId": "ami-b6760fc5"
+        "ImageId": "ami-a1491ad2"
       },
       "eu-central-1": {
-        "ImageId": "ami-f562909a"
+        "ImageId": "ami-54f5303b"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-096cba68"
+        "ImageId": "ami-9cd57ffd"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-7934ee1a"
+        "ImageId": "ami-a900a3ca"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-22a49541"
+        "ImageId": "ami-5781be34"
       }
     }
   },
@@ -110,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.7.2"
+      "Default": "v1.8.1"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v0.17.1"
+      "Default": "v1.1.0"
     }
   },
   "Conditions": {
@@ -457,6 +460,9 @@
                     "ecs:ListClusters",
                     "ecs:ListContainerInstances",
                     "ecs:DescribeContainerInstances",
+		    "ecs:ListServices",
+                    "ecs:DescribeTasks",
+                    "ecs:DescribeServices",
                     "ec2:DescribeInstances",
                     "ec2:DescribeTags",
                     "autoscaling:DescribeAutoScalingInstances"

--- a/aws/ecs/packer/build-all-amis.sh
+++ b/aws/ecs/packer/build-all-amis.sh
@@ -7,14 +7,15 @@ if [ -z "${AWS_ACCESS_KEY_ID+x}" -a -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
 fi
 
 # Taken from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html
-BASE_AMIS=('us-east-1:ami-3d55272a'
-	   'us-west-1:ami-444d0224'
-	   'us-west-2:ami-1ccd1f7c'
-	   'eu-west-1:ami-b6760fc5'
-	   'eu-central-1:ami-f562909a'
-	   'ap-northeast-1:ami-096cba68'
-	   'ap-southeast-1:ami-7934ee1a'
-	   'ap-southeast-2:ami-22a49541'
+BASE_AMIS=('us-east-1:ami-eca289fb'
+	   'us-east-2:ami-446f3521'
+	   'us-west-1:ami-9fadf8ff'
+	   'us-west-2:ami-7abc111a'
+	   'eu-west-1:ami-a1491ad2'
+	   'eu-central-1:ami-54f5303b'
+	   'ap-northeast-1:ami-9cd57ffd'
+	   'ap-southeast-1:ami-a900a3ca'
+	   'ap-southeast-2:ami-5781be34'
 	  )
 
 # Mimic associative arrays using ":" to compose keys and values,

--- a/aws/ecs/packer/template.json
+++ b/aws/ecs/packer/template.json
@@ -49,13 +49,13 @@
       "sudo yum -y install python-pip jq",
       "sudo python-pip install awscli",
 
-      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.7.2/weave -o /usr/local/bin/weave",
+      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.8.1/weave -o /usr/local/bin/weave",
       "sudo chmod +x /usr/local/bin/weave",
       "sudo /usr/local/bin/weave setup",
 
-      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v0.17.1/scope -o /usr/local/bin/scope",
+      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v1.1.0/scope -o /usr/local/bin/scope",
       "sudo chmod +x /usr/local/bin/scope",
-      "docker pull weaveworks/scope:0.17.1",
+      "docker pull weaveworks/scope:1.1.0",
 
 
       "sudo mv /home/ec2-user/weave.conf /etc/init/weave.conf",

--- a/aws/ecs/packer/to-upload/run.sh
+++ b/aws/ecs/packer/to-upload/run.sh
@@ -22,16 +22,14 @@ run_scope() {
 	while is_container_running weavescope; do sleep 2; done
 
 	# launch scope
-	ARGS=""
+	ARGS="--probe.ecs=true"
 	if [ -e /etc/weave/scope.config ]; then
 	    . /etc/weave/scope.config
 	fi
 	if [ -n "${SERVICE_TOKEN+x}" ]; then
-	    succeed_or_die scope launch "--service-token=$SERVICE_TOKEN"
-	else
-	    # Connect to the Scope apps in the weave network
-	    succeed_or_die scope launch
+	    ARGS="$ARGS --service-token=$SERVICE_TOKEN"
 	fi
+	succeed_or_die scope launch $ARGS
     done
 }
 


### PR DESCRIPTION
* Update Weave Net to 1.8.1
* Update Weave Scope to the upcoming 1.1.0 release (https://github.com/weaveworks/scope/pull/2033)
* Update base ECS images (including new Ohio region)
* Add documentation for new actions required for Scope ECS views

Depends on  https://github.com/weaveworks/scope/pull/2033 (which is turn depends on https://github.com/weaveworks/scope/pull/2026 )