### PR TITLE
Update Net & Scope versions to 1.9.4 and 1.3.0 respectively

### DIFF
--- a/aws/ecs/CHANGELOG.md
+++ b/aws/ecs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 New features:
 - Update base AMIs to 2016.09.g, Weave Scope to 1.3.0 and Weave Net version to 1.9.4
-[#108](github.com/weaveworks/integrations/pull/108)
+[#123](github.com/weaveworks/integrations/pull/123)
 
 ## Weaveworks ECS Image (2016-11-29)
 New features [#117](github.com/weaveworks/integrations/pull/117):

--- a/aws/ecs/CHANGELOG.md
+++ b/aws/ecs/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## Weaveworks ECS Image (2016-11-29)
 New features [#117](github.com/weaveworks/integrations/pull/117):
-- Update Weave Net to 1.8.1
-- Update Weave Scope to 1.1.0
+- Update Weave Net to 1.9.3
+- Update Weave Scope to 1.2.1
 - Enable Scope ECS views
 - Add documentation for new actions required for Scope ECS views
 - Update base ECS images (including new Ohio region)
+
+## Weaveworks ECS Image (2017-03-08)
+
+New features:
+- Update base AMIs to 2016.03.i, Weave Scope to 1.2.1 and Weave Net Version to 1.9.3 [#108](github.com/weaveworks/integrations/pull/108)
 
 ## Weaveworks ECS Image (2016-09-22)
 

--- a/aws/ecs/CHANGELOG.md
+++ b/aws/ecs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Weaveworks ECS Image (2017-03-29)
+
+New features:
+- Update base AMIs to 2016.09.g, Weave Scope to 1.3.0 and Weave Net version to 1.9.4
+[#108](github.com/weaveworks/integrations/pull/108)
+
 ## Weaveworks ECS Image (2016-11-29)
 New features [#117](github.com/weaveworks/integrations/pull/117):
 - Update Weave Net to 1.9.3
@@ -5,11 +11,6 @@ New features [#117](github.com/weaveworks/integrations/pull/117):
 - Enable Scope ECS views
 - Add documentation for new actions required for Scope ECS views
 - Update base ECS images (including new Ohio region)
-
-## Weaveworks ECS Image (2017-03-08)
-
-New features:
-- Update base AMIs to 2016.03.i, Weave Scope to 1.2.1 and Weave Net Version to 1.9.3 [#108](github.com/weaveworks/integrations/pull/108)
 
 ## Weaveworks ECS Image (2016-09-22)
 

--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -8,7 +8,7 @@ To make [Weave Net](http://weave.works/net) and
 [Amazon ECS](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html),
 a set of Amazon Machine Images (AMIs) are provided. These AMIs are fully
 compatible with the
-[ECS-Optimized Amazon Linux AMI](https://aws.amazon.com/marketplace/pp/B00U6QTYI2).
+[ECS-Optimized Amazon Linux AMI](https://aws.amazon.com/marketplace/pp/B06XS8WHGJ).
 
 The following are the latest supported Weave AMIs for each region:
 
@@ -18,25 +18,27 @@ not remove it and respect the format! -->
 
 | Region         | AMI          |
 |----------------|--------------|
-| us-east-1      | ami-c63709d1 |
-| us-east-2      | ami-4788d222 |
-| us-west-1      | ami-28e7b348 |
-| us-west-2      | ami-c62f81a6 |
-| eu-west-1      | ami-25adf356 |
-| eu-central-1   | ami-7fd31410 |
-| ap-northeast-1 | ami-cb1eafaa |
-| ap-southeast-1 | ami-35822f56 |
-| ap-southeast-2 | ami-06300965 |
+| us-east-1      | ami-f560d8e3 |
+| us-east-2      | ami-13e2c676 |
+| us-west-1      | ami-95cc97f5 |
+| us-west-2      | ami-4fe87c2f |
+| eu-west-1      | ami-13c8f475 |
+| eu-west-2      | ami-8a6276ee |
+| eu-central-1   | ami-216dbc4e |
+| ap-northeast-1 | ami-b2efb5d5 |
+| ap-southeast-1 | ami-e152ee82 |
+| ap-southeast-2 | ami-ac1b14cf |
+| ca-central-1   | ami-8104b9e5 |
 
 
 ## What's in the Weave ECS AMIs?
 
 These latest Weave ECS AMIs are based on Amazon's
 [ECS-Optimized Amazon Linux AMI](https://aws.amazon.com/marketplace/pp/B00U6QTYI2),
-version `2016.09.b` and also includes:
+version `2016.09.g` and also includes:
 
-* [Weave Net 1.8.1](https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-181)
-* [Weave Scope 1.1.0](https://github.com/weaveworks/scope/blob/master/CHANGELOG.md#release-110)
+* [Weave Net 1.9.3](https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-193)
+* [Weave Scope 1.3.0](https://github.com/weaveworks/scope/blob/master/CHANGELOG.md#release-130)
 
 
 ## Deployment Requirements

--- a/aws/ecs/cloudformation-identiorca.json
+++ b/aws/ecs/cloudformation-identiorca.json
@@ -658,7 +658,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.8.1",
+                      "v1.9.3",
                       "weave"
                     ]
                   ]
@@ -671,7 +671,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v1.1.0",
+                      "v1.2.1",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation-identiorca.json
+++ b/aws/ecs/cloudformation-identiorca.json
@@ -55,31 +55,37 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-eca289fb"
+        "ImageId": "ami-275ffe31"
       },
       "us-east-2": {
-        "ImageId": "ami-446f3521"
+        "ImageId": "ami-62745007"
       },      
       "us-west-1": {
-        "ImageId": "ami-9fadf8ff"
+        "ImageId": "ami-689bc208"
       },
       "us-west-2": {
-        "ImageId": "ami-7abc111a"
+        "ImageId": "ami-62d35c02"
       },
       "eu-west-1": {
-        "ImageId": "ami-a1491ad2"
+        "ImageId": "ami-95f8d2f3"
+      },
+      "eu-west-2": {
+        "ImageId": "ami-bf9481db"
       },
       "eu-central-1": {
-        "ImageId": "ami-54f5303b"
+        "ImageId": "ami-085e8a67"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-9cd57ffd"
+        "ImageId": "ami-f63f6f91"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-a900a3ca"
+        "ImageId": "ami-b4ae1dd7"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-5781be34"
+        "ImageId": "ami-fbe9eb98"
+      },
+      "ca-central-1": {
+        "ImageId": "ami-ee58e58a"
       }
     }
   },

--- a/aws/ecs/cloudformation-identiorca.json
+++ b/aws/ecs/cloudformation-identiorca.json
@@ -658,7 +658,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.9.3",
+                      "v1.9.4",
                       "weave"
                     ]
                   ]
@@ -671,7 +671,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v1.2.1",
+                      "v1.3.0",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -15,31 +15,37 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-eca289fb"
+        "ImageId": "ami-275ffe31"
       },
       "us-east-2": {
-        "ImageId": "ami-446f3521"
+        "ImageId": "ami-62745007"
       },      
       "us-west-1": {
-        "ImageId": "ami-9fadf8ff"
+        "ImageId": "ami-689bc208"
       },
       "us-west-2": {
-        "ImageId": "ami-7abc111a"
+        "ImageId": "ami-62d35c02"
       },
       "eu-west-1": {
-        "ImageId": "ami-a1491ad2"
+        "ImageId": "ami-95f8d2f3"
+      },
+      "eu-west-2": {
+        "ImageId": "ami-bf9481db"
       },
       "eu-central-1": {
-        "ImageId": "ami-54f5303b"
+        "ImageId": "ami-085e8a67"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-9cd57ffd"
+        "ImageId": "ami-f63f6f91"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-a900a3ca"
+        "ImageId": "ami-b4ae1dd7"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-5781be34"
+        "ImageId": "ami-fbe9eb98"
+      },
+      "ca-central-1": {
+        "ImageId": "ami-ee58e58a"
       }
     }
   },

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -113,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.9.3"
+      "Default": "v1.9.4"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v1.2.1"
+      "Default": "v1.3.0"
     }
   },
   "Conditions": {

--- a/aws/ecs/cloudformation-larger-app.json
+++ b/aws/ecs/cloudformation-larger-app.json
@@ -113,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.8.1"
+      "Default": "v1.9.3"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v1.1.0"
+      "Default": "v1.2.1"
     }
   },
   "Conditions": {

--- a/aws/ecs/cloudformation-no-app.json
+++ b/aws/ecs/cloudformation-no-app.json
@@ -542,7 +542,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.9.3",
+                      "v1.9.4",
                       "weave"
                     ]
                   ]
@@ -555,7 +555,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v1.2.1",
+                      "v1.3.0",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation-no-app.json
+++ b/aws/ecs/cloudformation-no-app.json
@@ -542,7 +542,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/weave/releases/download",
-                      "v1.8.1",
+                      "v1.9.3",
                       "weave"
                     ]
                   ]
@@ -555,7 +555,7 @@
                     "/",
                     [
                       "https://github.com/weaveworks/scope/releases/download",
-                      "v1.1.0",
+                      "v1.2.1",
                       "scope"
                     ]
                   ]

--- a/aws/ecs/cloudformation-no-app.json
+++ b/aws/ecs/cloudformation-no-app.json
@@ -36,31 +36,37 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-eca289fb"
+        "ImageId": "ami-275ffe31"
       },
       "us-east-2": {
-        "ImageId": "ami-446f3521"
+        "ImageId": "ami-62745007"
       },      
       "us-west-1": {
-        "ImageId": "ami-9fadf8ff"
+        "ImageId": "ami-689bc208"
       },
       "us-west-2": {
-        "ImageId": "ami-7abc111a"
+        "ImageId": "ami-62d35c02"
       },
       "eu-west-1": {
-        "ImageId": "ami-a1491ad2"
+        "ImageId": "ami-95f8d2f3"
+      },
+      "eu-west-2": {
+        "ImageId": "ami-bf9481db"
       },
       "eu-central-1": {
-        "ImageId": "ami-54f5303b"
+        "ImageId": "ami-085e8a67"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-9cd57ffd"
+        "ImageId": "ami-f63f6f91"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-a900a3ca"
+        "ImageId": "ami-b4ae1dd7"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-5781be34"
+        "ImageId": "ami-fbe9eb98"
+      },
+      "ca-central-1": {
+        "ImageId": "ami-ee58e58a"
       }
     }
   },

--- a/aws/ecs/cloudformation.json
+++ b/aws/ecs/cloudformation.json
@@ -15,31 +15,37 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-eca289fb"
+        "ImageId": "ami-275ffe31"
       },
       "us-east-2": {
-        "ImageId": "ami-446f3521"
+        "ImageId": "ami-62745007"
       },      
       "us-west-1": {
-        "ImageId": "ami-9fadf8ff"
+        "ImageId": "ami-689bc208"
       },
       "us-west-2": {
-        "ImageId": "ami-7abc111a"
+        "ImageId": "ami-62d35c02"
       },
       "eu-west-1": {
-        "ImageId": "ami-a1491ad2"
+        "ImageId": "ami-95f8d2f3"
+      },
+      "eu-west-2": {
+        "ImageId": "ami-bf9481db"
       },
       "eu-central-1": {
-        "ImageId": "ami-54f5303b"
+        "ImageId": "ami-085e8a67"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-9cd57ffd"
+        "ImageId": "ami-f63f6f91"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-a900a3ca"
+        "ImageId": "ami-b4ae1dd7"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-5781be34"
+        "ImageId": "ami-fbe9eb98"
+      },
+      "ca-central-1": {
+        "ImageId": "ami-ee58e58a"
       }
     }
   },

--- a/aws/ecs/cloudformation.json
+++ b/aws/ecs/cloudformation.json
@@ -113,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.9.3"
+      "Default": "v1.9.4"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v1.2.1"
+      "Default": "v1.3.0"
     }
   },
   "Conditions": {

--- a/aws/ecs/cloudformation.json
+++ b/aws/ecs/cloudformation.json
@@ -113,12 +113,12 @@
     "WeaveNetVersion": {
       "Type": "String",
       "Description": "Version of Weave Net to install",
-      "Default": "v1.8.1"
+      "Default": "v1.9.3"
     },
     "WeaveScopeVersion": {
       "Type": "String",
       "Description": "Version of Weave Scope to install",
-      "Default": "v1.1.0"
+      "Default": "v1.2.1"
     }
   },
   "Conditions": {

--- a/aws/ecs/packer/build-all-amis.sh
+++ b/aws/ecs/packer/build-all-amis.sh
@@ -7,15 +7,17 @@ if [ -z "${AWS_ACCESS_KEY_ID+x}" -a -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
 fi
 
 # Taken from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html
-BASE_AMIS=('us-east-1:ami-eca289fb'
-	   'us-east-2:ami-446f3521'
-	   'us-west-1:ami-9fadf8ff'
-	   'us-west-2:ami-7abc111a'
-	   'eu-west-1:ami-a1491ad2'
-	   'eu-central-1:ami-54f5303b'
-	   'ap-northeast-1:ami-9cd57ffd'
-	   'ap-southeast-1:ami-a900a3ca'
-	   'ap-southeast-2:ami-5781be34'
+BASE_AMIS=('us-east-1:ami-275ffe31'
+	   'us-east-2:ami-62745007'
+	   'us-west-1:ami-689bc208'
+	   'us-west-2:ami-62d35c02'
+	   'eu-west-1:ami-95f8d2f3'
+	   'eu-west-2:ami-bf9481db'
+	   'eu-central-1:ami-085e8a67'
+	   'ap-northeast-1:ami-f63f6f91'
+	   'ap-southeast-1:ami-b4ae1dd7'
+	   'ap-southeast-2:ami-fbe9eb98'
+	   'ca-central-1:ami-ee58e58a'
 	  )
 
 # Mimic associative arrays using ":" to compose keys and values,

--- a/aws/ecs/packer/template.json
+++ b/aws/ecs/packer/template.json
@@ -49,13 +49,13 @@
       "sudo yum -y install python-pip jq",
       "sudo python-pip install awscli",
 
-      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.8.1/weave -o /usr/local/bin/weave",
+      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.9.3/weave -o /usr/local/bin/weave",
       "sudo chmod +x /usr/local/bin/weave",
       "sudo /usr/local/bin/weave setup",
 
-      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v1.1.0/scope -o /usr/local/bin/scope",
+      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v1.2.1/scope -o /usr/local/bin/scope",
       "sudo chmod +x /usr/local/bin/scope",
-      "docker pull weaveworks/scope:1.1.0",
+      "docker pull weaveworks/scope:1.2.1",
 
 
       "sudo mv /home/ec2-user/weave.conf /etc/init/weave.conf",

--- a/aws/ecs/packer/template.json
+++ b/aws/ecs/packer/template.json
@@ -49,13 +49,13 @@
       "sudo yum -y install python-pip jq",
       "sudo python-pip install awscli",
 
-      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.9.3/weave -o /usr/local/bin/weave",
+      "sudo curl -L https://github.com/weaveworks/weave/releases/download/v1.9.4/weave -o /usr/local/bin/weave",
       "sudo chmod +x /usr/local/bin/weave",
       "sudo /usr/local/bin/weave setup",
 
-      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v1.2.1/scope -o /usr/local/bin/scope",
+      "sudo curl -L https://github.com/weaveworks/scope/releases/download/v1.3.0/scope -o /usr/local/bin/scope",
       "sudo chmod +x /usr/local/bin/scope",
-      "docker pull weaveworks/scope:1.2.1",
+      "docker pull weaveworks/scope:1.3.0",
 
 
       "sudo mv /home/ec2-user/weave.conf /etc/init/weave.conf",


### PR DESCRIPTION
Update all of the CloudFormation templates and the ECS AMI with current versions of Net & Scope.

Fixes: https://github.com/weaveworks/integrations/issues/121
Fixes: https://github.com/weaveworks/integrations/issues/122
