### PR TITLE
Use service token, if known, for Weave Net peer discovery

### DIFF
--- a/aws/ecs/packer/to-upload/run.sh
+++ b/aws/ecs/packer/to-upload/run.sh
@@ -47,8 +47,16 @@ run_weave() {
   while true; do
       # verify that weave is not running
       while is_container_running weave; do sleep 2; done
+      # get the service token from scope config
+      if [ -e /etc/weave/scope.config ]; then
+	      . /etc/weave/scope.config
+	  fi
       # launch weave
-      PEERS=$(succeed_or_die /etc/weave/peers.sh)
+      if [ -n "${SERVICE_TOKEN+x}" ]; then
+          PEERS="--token=$SERVICE_TOKEN"
+      else
+          PEERS=$(succeed_or_die /etc/weave/peers.sh)
+      fi
       succeed_or_die weave launch --plugin=false --hostname-from-label 'com.amazonaws.ecs.container-name' $PEERS
   done
 }


### PR DESCRIPTION
If a service token has been supplied [as described](https://www.weave.works/docs/scope/latest/ami/#running-weave-scope-in-weave-cloud) then use it to do Weave Net peer discovery instead of relying on the AWS API.

This is a possible fix for #134 and #135 

Would need to update the instructions which are [in the Scope repo](https://github.com/weaveworks/scope/blob/master/site/ami.md)