### PR TITLE
Leave AWS credentials as environment variables

### DIFF
--- a/aws/ecs/packer/build-all-amis.sh
+++ b/aws/ecs/packer/build-all-amis.sh
@@ -58,7 +58,7 @@ function invoke_packer() {
     if [ -n "${RELEASE+x}" ]; then
 	AMI_GROUPS="all"
     fi
-    packer build -var "ami_groups=${AMI_GROUPS}" -var "aws_access_key=${AWS_ACCESS_KEY_ID}" -var "aws_secret_key=${AWS_SECRET_ACCESS_KEY}" -var "aws_region=$1" -var "source_ami=$2" template.json > $LOGFILE
+    packer build -var "ami_groups=${AMI_GROUPS}" -var "aws_region=$1" -var "source_ami=$2" template.json > $LOGFILE
     if [ "$?" = 0 ]; then
 	echo "Success: $(tail -n 1 $LOGFILE)"
 	rm $LOGFILE

--- a/aws/ecs/packer/template.json
+++ b/aws/ecs/packer/template.json
@@ -8,8 +8,6 @@
   },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "{{user `aws_region`}}",
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "t2.micro",


### PR DESCRIPTION
They work fine that way, and better if you need to set AWS_SESSION_TOKEN.
